### PR TITLE
[ci skip] update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ services:
 - An [IBM Cloud account](https://cloud.ibm.com/registration).
 - A [Secrets Manager service instance](https://cloud.ibm.com/catalog/services/secrets-manager).
 - An [IBM Cloud API key](https://cloud.ibm.com/iam/apikeys) that allows the SDK to access your account.
-- Java 8 or above.
+- Java 8
 
 ## Installation
 


### PR DESCRIPTION
Java 11 is not supported yet so removing “and above” from version statement